### PR TITLE
Add basic support for NPRE standard exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This package checks if the application resources are running as they should and 
 
 - Highly extensible and configurable: you can create new checkers and notifiers very easily, and you can virtually change everything on it.
 - Easy configuration: uses YAML as configuration files
-- Resilient resource checker: if the framework is working and at least one notification channel, you should receive notification messages. 
+- Resilient resource checker: if the framework is working and at least one notification channel, you should receive notification messages.
 - Built-in notification system: get notifications via mail, slack, telegram or anything else you need.
 - Routes for: panel, json result, string result and resource.
 - Configurable panel design.
@@ -26,7 +26,7 @@ This package checks if the application resources are running as they should and 
 - View app error messages right in the panel.
 - Http response codes 200 and 500, on error, for services like [Envoyer](https://envoyer.io) to keep track of your app health.
 
-## Built-in Resources 
+## Built-in Resources
 
 Heath has pre-configured resource checkers for the following services:
 
@@ -79,10 +79,10 @@ Heath has pre-configured resource checkers for the following services:
 - ServerUptime
 - Sshd
 - Supervisor
- 
-But you can add anything else you need, you just have to find the right checker to use or just create a new checker for your resource. 
 
-## Easy Configuration 
+But you can add anything else you need, you just have to find the right checker to use or just create a new checker for your resource.
+
+## Easy Configuration
 
 Creating new resources monitors is easy, just create a new YAML file in app's config/health folder and it's done. Here's some examples:
 
@@ -118,7 +118,7 @@ Creating new resources monitors is easy, just create a new YAML file in app's co
     pid_file_missing_not_locked: 'Process ID file is not being used by any process: %s.'
     column_size: 4
 
-## Screenshots 
+## Screenshots
 
 ### Panel
 
@@ -134,7 +134,7 @@ If you have lots of services to check, you may change the default panel design t
 
 ![default panel](docs/images/error-single-4-columns.png)
 
-### Error Messages 
+### Error Messages
 
 Mouse over a failing resource and get instant access to the error message:
 
@@ -151,6 +151,15 @@ Here's an example of notification sent via Slack:
 ![default panel](docs/images/slack.png)
 
 ## Artisan Console Commands
+
+The health check commands below also return an exit code in a standard format:
+
+| Numeric Value | Service Status | Status Description                                                                                  |
+|---------------|----------------|-----------------------------------------------------------------------------------------------------|
+|       0       |       OK       | Service and appears to be functioning properly                                                      |
+|       1       |     Warning    | Check ran okay, but was above some "warning" threshold                                              |
+|       2       |    Critical    | The check detected service is not running or is above a "critical" threshold                        |
+|       3       |     Unknown    | Settings for the service check may be misconfigured and is preventing the check for being performed |
 
 ### health:panel
 
@@ -214,11 +223,11 @@ Add the Service Provider to your `config/app.php`:
 ## Hit The Health Panel
 
     http://yourdomain.com/health/panel
-    
+
 ## Configure All The Things
 
 Almost everything is easily configurable in this package:
- 
+
 - Panel name
 - Title and messages
 - Resource checkers
@@ -246,7 +255,7 @@ Some of the checkers need you to configure the proper binary path for the checke
 
 ## Allowing Slack Notifications
 
-To receive notifications via Slack, you'll have to setup [Incoming Webhooks](https://api.slack.com/incoming-webhooks) and add this method to your User model with your webhook: 
+To receive notifications via Slack, you'll have to setup [Incoming Webhooks](https://api.slack.com/incoming-webhooks) and add this method to your User model with your webhook:
 
     /**
      * Route notifications for the Slack channel.
@@ -260,13 +269,13 @@ To receive notifications via Slack, you'll have to setup [Incoming Webhooks](htt
 
 ## Cache
 
-When Health result is cached, you can flush the cache to make it process all resources again by adding `?flush=true` to the url: 
+When Health result is cached, you can flush the cache to make it process all resources again by adding `?flush=true` to the url:
 
     http://yourdomain.com/health/panel?flush=true
 
 ## Events
 
-If you prefer to build you own notifications systems, you can disable it and listen for the following event  
+If you prefer to build you own notifications systems, you can disable it and listen for the following event
 
     PragmaRX\Health\Events\RaiseHealthIssue::class
 
@@ -281,17 +290,17 @@ Broadcasting checker is done via ping and pong system. The broadcast checker wil
     var io = require('socket.io')(server);
     var Redis = require('ioredis');
     var redis = new Redis();
-    
+
     redis.subscribe('pragmarx-health-broadcasting-channel');
-    
+
     redis.on('message', function (channel, message) {
         message = JSON.parse(message);
-    
+
         if (message.event == 'PragmaRX\\Health\\Events\\HealthPing') {
             request.get(message.data.callbackUrl + '?data=' + JSON.stringify(message.data));
         }
     });
-    
+
     server.listen(3000);
 
 ### Pusher
@@ -305,19 +314,19 @@ Broadcasting checker is done via ping and pong system. The broadcast checker wil
                 var pusher = new Pusher('YOUR-PUSHER-KEY', {
                     encrypted: true
                 });
-    
+
                 var channel = pusher.subscribe('pragmarx-health-broadcasting-channel');
-    
+
                 channel.bind('PragmaRX\\Health\\Events\\HealthPing', function(data) {
                     var request = (new XMLHttpRequest());
-    
+
                     request.open("GET", data.callbackUrl + '?data=' + JSON.stringify(data));
-    
+
                     request.send();
                 });
             </script>
         </head>
-    
+
         <body>
             Pusher waiting for events...
         </body>
@@ -328,12 +337,12 @@ Broadcasting checker is done via ping and pong system. The broadcast checker wil
 ``` php
 $generalHealthState = app('pragmarx.health')->checkResources();
 
-// or 
+// or
 
 $databaseHealthy = app('pragmarx.health')->checkResource('database')->isHealthy();
 ```
 
-Checking in artisan commands example: 
+Checking in artisan commands example:
 
 ```
 Artisan::command('database:health', function () {
@@ -349,18 +358,18 @@ To use it on Lumen, you'll probably need to do something like this on your `boot
 
     $app->instance('path.config', app()->basePath() . DIRECTORY_SEPARATOR . 'config');
     $app->instance('path.storage', app()->basePath() . DIRECTORY_SEPARATOR . 'storage');
-    
+
     $app->withFacades();
-    
+
     $app->singleton('Illuminate\Contracts\Routing\ResponseFactory', function ($app) {
         return new \Illuminate\Routing\ResponseFactory(
             $app['Illuminate\Contracts\View\Factory'],
             $app['Illuminate\Routing\Redirector']
         );
     });
-    
+
     $app->register(PragmaRX\Health\ServiceProvider::class);
- 
+
 ## Testing
 
 ``` bash

--- a/src/Commands.php
+++ b/src/Commands.php
@@ -4,7 +4,7 @@ namespace PragmaRX\Health;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
-use Illuminate\Support\Result;
+use PragmaRX\Health\Support\Result;
 use PragmaRX\Health\Service as HealthService;
 
 class Commands
@@ -93,8 +93,8 @@ class Commands
                 return [
                     "{$target->resource->name} ({$target->display})",
                     $target->result->healthy
-                        ? '<info>healthy</info>'
-                        : '<fg=red>failing</fg=red>',
+                        ? '<info>'.$target->result->getStatus().'</info>'
+                        : '<fg=red>'.$target->result->getStatus().'</fg=red>',
                     $this->normalizeMessage($target->result->errorMessage),
                 ];
             })

--- a/src/Console/Commands/HealthCheckCommand.php
+++ b/src/Console/Commands/HealthCheckCommand.php
@@ -24,16 +24,12 @@ class HealthCheckCommand extends Command
     /**
      * @param Commands $commands
      *
-     * @return int Exit code: 0 = success; 1 = failed
+     * @return int Exit code: 0 = success; 2 = failed
      *
      * @throws \Exception
      */
     public function handle(Commands $commands)
     {
-        if (false === $commands->check($this)) {
-            return 1;
-        }
-
-        return 0;
+        return $commands->check($this);
     }
 }

--- a/src/Console/Commands/HealthPanelCommand.php
+++ b/src/Console/Commands/HealthPanelCommand.php
@@ -22,10 +22,10 @@ class HealthPanelCommand extends Command
     protected $description = 'Show all resources and their current health states.';
 
     /**
-     * @return void
+     * @return int Exit code: 0 = success; 2 = failed
      */
-    public function handle(Commands $commands): void
+    public function handle(Commands $commands): int
     {
-        $commands->panel($this);
+        return $commands->panel($this);
     }
 }

--- a/src/Http/Controllers/Health.php
+++ b/src/Http/Controllers/Health.php
@@ -5,6 +5,7 @@ namespace PragmaRX\Health\Http\Controllers;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\File;
 use PragmaRX\Health\Service;
+use Illuminate\Http\Request;
 
 class Health extends Controller
 {
@@ -65,12 +66,14 @@ class Health extends Controller
      * @return mixed
      * @throws \Exception
      */
-    public function string()
+    public function string(Request $request)
     {
+        $filters = $request->get('filters');
+
         $this->healthService->setAction('string');
 
         return response(
-            $this->healthService->string()
+            $this->healthService->string($filters)
         );
     }
 

--- a/src/Support/Result.php
+++ b/src/Support/Result.php
@@ -8,10 +8,10 @@ class Result
      * States the result of the check could be in
      * Further reading: https://nagios-plugins.org/doc/guidelines.html#AEN78
      */
-    const OK = 'ok';
-    const WARNING = 'warning';
-    const CRITICAL = 'critical';
-    const UNKNOWN = 'unknown';
+    const OK = 'OK';
+    const WARNING = 'Warning';
+    const CRITICAL = 'Critical';
+    const UNKNOWN = 'Unknown';
 
     /**
      * Defaults the state of the result to unknown

--- a/src/Support/Result.php
+++ b/src/Support/Result.php
@@ -5,6 +5,20 @@ namespace PragmaRX\Health\Support;
 class Result
 {
     /**
+     * States the result of the check could be in
+     * Further reading: https://nagios-plugins.org/doc/guidelines.html#AEN78
+     */
+    const OK = 'ok';
+    const WARNING = 'warning';
+    const CRITICAL = 'critical';
+    const UNKNOWN = 'unknown';
+
+    /**
+     * Defaults the state of the result to unknown
+     */
+    protected $state = self::UNKNOWN;
+
+    /**
      * @var bool
      */
     public $healthy;
@@ -34,6 +48,9 @@ class Result
         $this->healthy = $healthy;
 
         $this->errorMessage = $errorMessage;
+
+        // Currently the status is inferred from the $healthy flag until full support is added.
+        $this->status = $healthy ? self::OK : self::CRITICAL;
     }
 
     /**
@@ -61,4 +78,14 @@ class Result
 
         return $this;
     }
+
+    /**
+     * Get the result's status of the check
+     *
+     * @return string one of the consts e.g. result::OK
+     */
+    public function getStatus(): string {
+        return $this->status;
+    }
+
 }

--- a/src/config/health.php
+++ b/src/config/health.php
@@ -263,6 +263,9 @@ return [
     'string' => [
         'glue' => '-',
         'ok' => 'OK',
+        'warning' => 'WARNING',
+        'critical' => 'CRITICAL',
+        'unknown' => 'UNKNOWN',
         'fail' => 'FAIL',
     ],
 


### PR DESCRIPTION
Related to https://github.com/antonioribeiro/health/issues/239 and https://github.com/antonioribeiro/health/issues/240

Upstream PR: https://github.com/antonioribeiro/health/pull/241

- Add exit code table and description to the README
- Also some automatic whitespace striping in README due to editor
- Add NPRE exit codes to the artisan commands which other monitoring tools utilise
- Kept current behaviour for OK/FAIL but reworked it to allow full support of the varying levels eventually
- Add filtering to the /health/string endpoint to only show the results the caller is interested in
- Adjust /health/string handling, adding more options but keeping backwards support for ok/fail messages.
- Add format option to the /health/resources/:resource endpoint to show an alternative format to json, with a summary of the service in plaintext
- Service status updated to return the highest level of severity (starting from OK == 0)

Example output
```
root@a01fe36051f6:/siteroot/api# php artisan health:panel
+--------------------------------------+----------+--------------------------------------------------------------+
| Resource                             | State    | Message                                                      |
+--------------------------------------+----------+--------------------------------------------------------------+
| App Key (default)                    | OK       |                                                              |
| Cache (default)                      | OK       |                                                              |
| Configuration Cached (default)       | Critical | Configuration is not cached                                  |
| Debug Mode (default)                 | Critical | Application is in debug mode                                 |
| Directory Permissions (default)      | OK       |                                                              |
| Disk Space (root)                    | OK       |                                                              |
| .env Exists (default)                | OK       |                                                              |
| Filesystem (default)                 | OK       |                                                              |
| Framework (default)                  | OK       |                                                              |
| LaravelServices (default)            | OK       |                                                              |
| LocalStorage (default)               | OK       |                                                              |
| Migrations Up to Date (default)      | OK       |                                                              |
| NginxServer (default)                | OK       |                                                              |
| Php (default)                        | OK       |                                                              |
| Queue (default)                      | OK       |                                                              |
| QueueWorkers (default)               | OK       |                                                              |
| RebootRequired (default)             | OK       |                                                              |
| Routes Cached (default)              | Critical | Routes are not cached                                        |
| ServerUptime (default)               | OK       | Looks like your server was recently rebooted, current uptime |
|                                      |          | is now "2 weeks 17 hours 56 minutes" and it was "1 week 6    |
|                                      |          | days 21 hours 4 minutes" before restart.                     |
| Supervisor (default)                 | OK       |                                                              |
+--------------------------------------+----------+--------------------------------------------------------------+
root@a01fe36051f6:/siteroot/api# echo $? # print out exit code
2
```

https://localhost/health/resources/queue?format=summary
```
OK: Queue is running as expected (Checked Sep 8 16:09:01)
```

https://localhost/health/resources/configuration-cached?format=summary
```
CRITICAL: Configuration is not cached (Checked Sep 8 16:09:27)
PragmaRX\Health\Checkers\Expression was used to determine the health
```