### PR TITLE
Allow for other statuses (e.g. UNKNOWN, WARNING) to be set

### DIFF
--- a/src/Checkers/Base.php
+++ b/src/Checkers/Base.php
@@ -51,9 +51,9 @@ abstract class Base implements Contract
      * @param null $errorMessage
      * @return Result
      */
-    public function makeResult($healthy = true, $errorMessage = null)
+    public function makeResult($healthy = true, $errorMessage = null, $status = '')
     {
-        return new Result($healthy, $errorMessage);
+        return new Result($healthy, $errorMessage, $status);
     }
 
     /**
@@ -74,7 +74,7 @@ abstract class Base implements Contract
      */
     protected function makeResultFromException($exception)
     {
-        return $this->makeResult(false, $exception->getMessage());
+        return $this->makeResult(false, $exception->getMessage(), Result::CRITICAL);
     }
 
     /**

--- a/src/Support/Result.php
+++ b/src/Support/Result.php
@@ -43,14 +43,14 @@ class Result
      */
     public $errorMessage;
 
-    public function __construct(bool $healthy = false, $errorMessage = null)
+    public function __construct(bool $healthy = false, $errorMessage = null, string $status = '')
     {
         $this->healthy = $healthy;
 
         $this->errorMessage = $errorMessage;
 
         // Currently the status is inferred from the $healthy flag until full support is added.
-        $this->status = $healthy ? self::OK : self::CRITICAL;
+        $this->status = $status ? $status : ($healthy ? self::OK : self::CRITICAL);
     }
 
     /**


### PR DESCRIPTION
By adding a 3rd parameter, we can set the status directly, instead of it being determined by the healthy flag on the first param.

For backwards compatibility I've left the other params as-is, but it could be reduced to just a status and errorMessage check. Any non-OK status should be considered unhealthy.